### PR TITLE
Harden executor/tmux command flow and prompt handling

### DIFF
--- a/src/executor/executor.test.ts
+++ b/src/executor/executor.test.ts
@@ -24,25 +24,14 @@ describe('Executor Feature', () => {
     const dummyCliCode = `
       const fs = require('fs');
       
-      // The prompt is passed as -p "$$(cat prompt-file.txt)" from executor.ts
-      // Node receives it as "$(cat prompt-file.txt)"
+      // The prompt is passed as -p with the resolved prompt text from the shell
       const args = process.argv.slice(2);
       const promptArgIndex = args.indexOf('-p');
       let promptText = 'default';
       
       if (promptArgIndex !== -1 && args[promptArgIndex + 1]) {
         const rawArg = args[promptArgIndex + 1];
-        // Extract the filename from "$(cat FILENAME)"
-        if (rawArg.startsWith('$(cat ') && rawArg.endsWith(')')) {
-           const filename = rawArg.slice(6, -1);
-           try {
-             promptText = fs.readFileSync(filename, 'utf8');
-           } catch (e) {
-             promptText = 'Error reading file: ' + filename;
-           }
-        } else {
-           promptText = rawArg;
-        }
+        promptText = rawArg;
       }
 
       console.log(JSON.stringify({ type: 'init', session_id: 'dummy-session-123' }));

--- a/src/executor/executor.ts
+++ b/src/executor/executor.ts
@@ -35,6 +35,10 @@ export function readSecrets(): Record<string, string> {
   return secrets;
 }
 
+function shellEscapeSingleQuoted(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
 export interface ExecutorOptions {
   group: RegisteredProject;
   workspacePath: string;
@@ -88,7 +92,7 @@ export class Executor {
           } else if (parsed.response) {
             await onOutput({ status: 'success', result: parsed.response });
           }
-        } catch (e) {
+        } catch {
           // Ignore non-JSON output from the shell or gemini
         }
       }
@@ -98,41 +102,50 @@ export class Executor {
 
     if (!sessionExists) {
       await bridge.createSession(workspacePath);
-      bridge.startTailing();
     }
 
+    bridge.startTailing();
+
     // Write prompt to a temp file to avoid bash escaping issues
-    const promptFile = path.join(workspacePath, `.prompt-${Date.now()}.txt`);
+    const stamp = `${Date.now()}-${process.pid}`;
+    const promptFile = path.join(workspacePath, `.prompt-${stamp}.txt`);
     fs.writeFileSync(promptFile, prompt);
 
     // Build exports for secrets
     const exportsArray = Object.entries(secrets).map(
-      ([k, v]) => `export ${k}="${(v as string).replace(/"/g, '\\"')}"`,
+      ([k, v]) => `export ${k}=${shellEscapeSingleQuoted(v as string)}`,
     );
     const exportsCmd = exportsArray.join('\n');
 
     const cliArgs = [
       '-p',
-      `"$(cat ${path.basename(promptFile)})"`,
+      '"$(cat \"$PROMPT_FILE\")"',
       '-y',
       '-o',
       'stream-json',
     ];
     if (sessionId) {
-      cliArgs.push('--resume', sessionId);
+      cliArgs.push('--resume', shellEscapeSingleQuoted(sessionId));
     }
 
     const cliCommand = codingCli || 'gemini';
 
-    const runScript = path.join(workspacePath, `.run-${Date.now()}.sh`);
+    const runScript = path.join(workspacePath, `.run-${stamp}.sh`);
     const scriptContent = `#!/bin/bash
+set -euo pipefail
+cd ${shellEscapeSingleQuoted(workspacePath)}
+PROMPT_FILE=${shellEscapeSingleQuoted(promptFile)}
+OUTPUT_FILE=${shellEscapeSingleQuoted(bridge.outputPath)}
+cleanup() {
+  rm -f -- "$PROMPT_FILE" "$0"
+}
+trap cleanup EXIT
 ${exportsCmd}
-${cliCommand} ${cliArgs.join(' ')} >> ${bridge.outputPath} 2>&1
+${cliCommand} ${cliArgs.join(' ')} >> "$OUTPUT_FILE" 2>&1
 `;
-    fs.writeFileSync(runScript, scriptContent);
+    fs.writeFileSync(runScript, scriptContent, { mode: 0o700 });
 
-    // Execute directly
-    await bridge.sendKeys(`bash ${path.basename(runScript)}`);
+    await bridge.sendKeys(`bash ${shellEscapeSingleQuoted(runScript)}`);
 
     return 'Dispatched instruction to the workspace agent.';
   }

--- a/src/executor/tmux.ts
+++ b/src/executor/tmux.ts
@@ -1,8 +1,36 @@
-import { spawn, exec, execSync, ChildProcess } from 'child_process';
+import { spawn, execSync, ChildProcess } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { logger } from '../core/logger.js';
+
+async function runTmux(args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tmux = spawn('tmux', args);
+    tmux.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`Tmux ${args[0]} exit code ${code}`));
+      }
+    });
+    tmux.on('error', (err) => {
+      reject(err);
+    });
+  });
+}
+
+async function runTmuxAllowCode(args: string[]): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const tmux = spawn('tmux', args);
+    tmux.on('close', (code) => {
+      resolve(code ?? 1);
+    });
+    tmux.on('error', (err) => {
+      reject(err);
+    });
+  });
+}
 
 export class TmuxBridge {
   private sessionId: string;
@@ -28,27 +56,9 @@ export class TmuxBridge {
       return;
     }
 
-    return new Promise((resolve, reject) => {
-      const tmux = spawn('tmux', [
-        'new-session',
-        '-d',
-        '-s',
-        this.sessionId,
-        '-c',
-        cwd,
-      ]);
-
-      tmux.on('close', async (code) => {
-        if (code === 0) {
-          logger.info({ sessionId: this.sessionId }, 'Tmux session created');
-          await this.injectEnv();
-          resolve();
-        } else {
-          logger.error({ code }, 'Failed to create tmux session');
-          reject(new Error(`Tmux exit code ${code}`));
-        }
-      });
-    });
+    await runTmux(['new-session', '-d', '-s', this.sessionId, '-c', cwd]);
+    logger.info({ sessionId: this.sessionId }, 'Tmux session created');
+    await this.injectEnv();
   }
 
   /**
@@ -119,7 +129,7 @@ export class TmuxBridge {
     // Ensure file exists
     fs.writeFileSync(this.outputFile, '', { flag: 'a' });
 
-    this.tailProc = spawn('tail', ['-f', this.outputFile]);
+    this.tailProc = spawn('tail', ['-n', '0', '-F', this.outputFile]);
     this.tailProc.stdout?.on('data', (data: Buffer) => {
       this.onData(data.toString());
     });
@@ -129,11 +139,8 @@ export class TmuxBridge {
   }
 
   async hasSession(): Promise<boolean> {
-    return new Promise((resolve) => {
-      exec(`tmux has-session -t ${this.sessionId}`, (err) => {
-        resolve(!err);
-      });
-    });
+    const code = await runTmuxAllowCode(['has-session', '-t', this.sessionId]);
+    return code === 0;
   }
 
   async killSession(): Promise<void> {
@@ -144,11 +151,13 @@ export class TmuxBridge {
     } catch {
       /* ignore */
     }
-    return new Promise((resolve) => {
-      exec(`tmux kill-session -t ${this.sessionId}`, () => {
-        resolve();
-      });
-    });
+    const code = await runTmuxAllowCode(['kill-session', '-t', this.sessionId]);
+    if (code !== 0) {
+      logger.debug(
+        { sessionId: this.sessionId, code },
+        'Tmux session did not exist during kill',
+      );
+    }
   }
 
   /**
@@ -156,19 +165,7 @@ export class TmuxBridge {
    * To capture output, append ` >> {outputFile} 2>&1` to the command.
    */
   async sendKeys(keys: string): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const tmux = spawn('tmux', [
-        'send-keys',
-        '-t',
-        this.sessionId,
-        keys,
-        'C-m',
-      ]);
-      tmux.on('close', (code) => {
-        if (code === 0) resolve();
-        else reject(new Error(`Tmux send-keys exit code ${code}`));
-      });
-    });
+    await runTmux(['send-keys', '-t', this.sessionId, keys, 'C-m']);
   }
 
   /** Get the output file path so callers can redirect command output to it. */


### PR DESCRIPTION
### Motivation
- Improve runtime safety when dispatching agent CLI work by eliminating fragile quoting and temp-file leaks that could break in workspaces with special characters. 
- Make tmux integration more robust to partial failures and log rotation so the output stream remains reliable for downstream consumers. 
- Replace ad-hoc shell `exec` usage with argument-based spawns to produce clearer error handling and reduce ENOENT/escape issues. 

### Description
- Add `shellEscapeSingleQuoted` and single-quote-escape secret/session values before emitting `export` or CLI arguments to avoid shell injection and quoting bugs. 
- Make prompt and run script paths absolute and safely quoted via `PROMPT_FILE`/`OUTPUT_FILE`, and add a `trap cleanup EXIT` so temporary files self-clean on script exit. 
- Always call `bridge.startTailing()` from the executor so output is streamed both for newly created and reused tmux sessions. 
- Refactor tmux invocations into `runTmux` / `runTmuxAllowCode` spawn helpers and replace `tail -f` with `tail -n 0 -F` to stream only new content and survive log rotation/truncation. 
- Update the executor test fixture so the dummy CLI aligns with the new `-p` prompt passing semantics. 

### Testing
- Ran `pnpm -s typecheck` and it completed successfully. 
- Ran `pnpm -s vitest run src/executor/executor.test.ts src/executor/tmux.test.ts`, which surfaced `spawn tmux ENOENT` because the test environment/container does not have the `tmux` binary installed, causing the test run to fail. 
- Note: in environments with `tmux` available the updated tests exercise the new quoting, script cleanup, and tailing behavior and are expected to pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8df2441a8832e82819e4da37b5144)