### PR TITLE
refactor(cli): centralize duplicated prompt and readConfig functions

### DIFF
--- a/cli/src/bootstrap.ts
+++ b/cli/src/bootstrap.ts
@@ -12,30 +12,14 @@
 
 import { execSync } from 'child_process';
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
-import readline from 'readline';
 import yaml from 'yaml';
-
-// Resolve project root (cli/ lives one level below root)
-const PROJECT_ROOT = path.resolve(import.meta.dirname, '..', '..');
-const HOME_DIR = process.env.HOME || os.homedir();
-const TICLAW_HOME = path.join(HOME_DIR, 'ticlaw');
-const CONFIG_PATH = path.join(TICLAW_HOME, 'config.yaml');
-
-function prompt(question: string, defaultValue?: string): Promise<string> {
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-  const suffix = defaultValue ? ` [${defaultValue}]` : '';
-  return new Promise((resolve) => {
-    rl.question(`${question}${suffix}: `, (answer) => {
-      rl.close();
-      resolve(answer.trim() || defaultValue || '');
-    });
-  });
-}
+import {
+  prompt,
+  PROJECT_ROOT,
+  TICLAW_HOME,
+  CONFIG_PATH,
+} from './utils.js';
 
 function detectCLIs(): Record<string, boolean> {
   const clis: Record<string, boolean> = {};

--- a/cli/src/env.ts
+++ b/cli/src/env.ts
@@ -9,34 +9,20 @@
 
 import { execSync } from 'child_process';
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
-import readline from 'readline';
 import yaml from 'yaml';
 import type { Command } from 'commander';
+import {
+  prompt,
+  readConfig,
+  TICLAW_HOME,
+  CONFIG_PATH,
+} from './utils.js';
 
-const PROJECT_ROOT = path.resolve(import.meta.dirname, '..', '..');
-const HOME_DIR = process.env.HOME || os.homedir();
-const TICLAW_HOME = path.join(HOME_DIR, 'ticlaw');
 const WORKSPACES_DIR = path.join(TICLAW_HOME, 'workspaces');
 const ENVS_DIR = path.join(TICLAW_HOME, 'envs');
-const CONFIG_PATH = path.join(TICLAW_HOME, 'config.yaml');
 const STORE_DIR = path.join(TICLAW_HOME, 'store');
 const GROUPS_DIR = path.join(TICLAW_HOME, 'groups');
-
-function prompt(question: string, defaultValue?: string): Promise<string> {
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-  const suffix = defaultValue ? ` [${defaultValue}]` : '';
-  return new Promise((resolve) => {
-    rl.question(`${question}${suffix}: `, (answer) => {
-      rl.close();
-      resolve(answer.trim() || defaultValue || '');
-    });
-  });
-}
 
 function ghAvailable(): boolean {
   try {
@@ -68,14 +54,6 @@ function searchRepos(query: string): RepoInfo[] {
     );
   } catch {
     return [];
-  }
-}
-
-function readConfig(): any {
-  try {
-    return yaml.parse(fs.readFileSync(CONFIG_PATH, 'utf-8')) || {};
-  } catch {
-    return {};
   }
 }
 

--- a/cli/src/service.ts
+++ b/cli/src/service.ts
@@ -6,14 +6,14 @@
 
 import { execSync } from 'child_process';
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
-import yaml from 'yaml';
-
-const PROJECT_ROOT = path.resolve(import.meta.dirname, '..', '..');
-const HOME_DIR = process.env.HOME || os.homedir();
-const TICLAW_HOME = path.join(HOME_DIR, 'ticlaw');
-const CONFIG_PATH = path.join(TICLAW_HOME, 'config.yaml');
+import {
+  readConfig,
+  PROJECT_ROOT,
+  HOME_DIR,
+  TICLAW_HOME,
+  CONFIG_PATH,
+} from './utils.js';
 
 function getPlatform(): 'macos' | 'linux' | 'unknown' {
   if (process.platform === 'darwin') return 'macos';
@@ -34,14 +34,6 @@ const LAUNCHD_PLIST = path.join(
 
 function getSystemdUnit(): string {
   return 'ticlaw.service';
-}
-
-function readConfig(): any {
-  try {
-    return yaml.parse(fs.readFileSync(CONFIG_PATH, 'utf-8')) || {};
-  } catch {
-    return {};
-  }
 }
 
 // --- Start ---

--- a/cli/src/skills.ts
+++ b/cli/src/skills.ts
@@ -11,8 +11,7 @@ import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import type { Command } from 'commander';
-
-const PROJECT_ROOT = path.resolve(import.meta.dirname, '..', '..');
+import { PROJECT_ROOT } from './utils.js';
 const SKILLS_DIR = path.join(PROJECT_ROOT, 'skills');
 const STATE_PATH = path.join(PROJECT_ROOT, '.ticlaw', 'state.json');
 

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -1,0 +1,38 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import readline from 'readline';
+import yaml from 'yaml';
+
+export const PROJECT_ROOT = path.resolve(import.meta.dirname, '..', '..');
+export const HOME_DIR = process.env.HOME || os.homedir();
+export const TICLAW_HOME = path.join(HOME_DIR, 'ticlaw');
+export const CONFIG_PATH = path.join(TICLAW_HOME, 'config.yaml');
+
+/**
+ * Prompts the user for input via the command line.
+ */
+export function prompt(question: string, defaultValue?: string): Promise<string> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  const suffix = defaultValue ? ` [${defaultValue}]` : '';
+  return new Promise((resolve) => {
+    rl.question(`${question}${suffix}: `, (answer) => {
+      rl.close();
+      resolve(answer.trim() || defaultValue || '');
+    });
+  });
+}
+
+/**
+ * Reads and parses the TiClaw configuration file.
+ */
+export function readConfig(): any {
+  try {
+    return yaml.parse(fs.readFileSync(CONFIG_PATH, 'utf-8')) || {};
+  } catch {
+    return {};
+  }
+}


### PR DESCRIPTION
Extracted `prompt` and `readConfig` functions, along with common path constants, into a new `cli/src/utils.ts` module to improve maintainability and follow DRY principles.

Changes:
- Created `cli/src/utils.ts` with shared functions and constants.
- Refactored `bootstrap.ts`, `env.ts`, `service.ts`, and `skills.ts` to use the new utility module.
- Cleaned up unused imports in the refactored files.

## Description

<!-- Briefly describe the change and its motivation -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / simplification
- [ ] Documentation
