### PR TITLE
fix: command injection and repo name validation in workspace tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,11 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild"
+    ]
   }
 }

--- a/src/__tests__/agent.test.ts
+++ b/src/__tests__/agent.test.ts
@@ -6,17 +6,18 @@ import * as ai from 'ai';
 vi.mock('ai', () => ({
   generateText: vi.fn(),
   tool: vi.fn((x) => x),
+  stepCountIs: vi.fn(),
 }));
 
 vi.mock('@openrouter/ai-sdk-provider', () => ({
   createOpenRouter: vi.fn().mockReturnValue(() => 'mock-model'),
 }));
 
-vi.mock('../env.js', () => ({
+vi.mock('../core/env.js', () => ({
   readEnvFile: vi.fn().mockReturnValue({ OPENROUTER_API_KEY: 'test-key' }),
 }));
 
-vi.mock('../logger.js', () => ({
+vi.mock('../core/logger.js', () => ({
   logger: {
     info: vi.fn(),
     error: vi.fn(),
@@ -27,13 +28,14 @@ vi.mock('../logger.js', () => ({
 
 // Mock the tools
 vi.mock('../tools/executor.js', () => ({
-  buildExecutorTool: vi.fn().mockReturnValue({
-    execute: vi.fn().mockResolvedValue('Executor called'),
+  buildSessionTools: vi.fn().mockReturnValue({
+    captureSessionTool: { execute: vi.fn() },
+    sendToSessionTool: { execute: vi.fn() },
   }),
 }));
 
-vi.mock('../tools/setup-workspace.js', () => ({
-  buildSetupWorkspaceTool: vi.fn().mockReturnValue({
+vi.mock('../tools/workspace.js', () => ({
+  buildWorkspaceTool: vi.fn().mockReturnValue({
     execute: vi.fn().mockResolvedValue('Setup called'),
   }),
 }));
@@ -65,18 +67,28 @@ describe('Agent Orchestrator', () => {
   });
 
   it('should call generateText with correct model and tools', async () => {
-    vi.mocked(ai.generateText).mockResolvedValueOnce({
+    vi.mocked(ai.generateText).mockResolvedValue({
       text: 'I have scheduled the requested work via tools.',
       toolCalls: [],
+      steps: [],
     } as any);
 
-    const result = await runAgentOrchestrator(dummyOpts);
+    vi.mocked(ai.stepCountIs).mockReturnValue(250 as any);
+
+    let result;
+    try {
+      result = await runAgentOrchestrator(dummyOpts);
+    } catch (e) {
+      console.error(e);
+      throw e;
+    }
 
     expect(ai.generateText).toHaveBeenCalled();
     const callArgs = vi.mocked(ai.generateText).mock.calls[0][0];
 
     expect((callArgs as any).system).toContain('You are TiClaw');
-    expect((callArgs as any).tools).toHaveProperty('executorTool');
+    expect((callArgs as any).tools).toHaveProperty('captureSessionTool');
+    expect((callArgs as any).tools).toHaveProperty('sendToSessionTool');
     expect((callArgs as any).tools).toHaveProperty('workspaceTool');
 
     expect(result).toBe('I have scheduled the requested work via tools.');

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -37,8 +37,8 @@ describe('router', () => {
     });
 
     it('should not remove unfinished internal tags', () => {
-        const input = 'Hello <internal>unclosed';
-        expect(stripInternalTags(input)).toBe('Hello <internal>unclosed');
+      const input = 'Hello <internal>unclosed';
+      expect(stripInternalTags(input)).toBe('Hello <internal>unclosed');
     });
   });
 

--- a/src/tools/workspace.ts
+++ b/src/tools/workspace.ts
@@ -1,6 +1,6 @@
 import { tool } from 'ai';
 import { z } from 'zod';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 
@@ -35,10 +35,16 @@ export const buildWorkspaceTool = (
       );
 
       try {
-        const parts = repoFullName.split('/');
-        if (parts.length !== 2) {
-          return `ERROR: Repository name must be in the format "owner/repo". Got: "${repoFullName}". Do NOT retry.`;
+        if (
+          !/^[a-zA-Z0-9][a-zA-Z0-9._-]*\/[a-zA-Z0-9._-]+$/.test(repoFullName)
+        ) {
+          return `ERROR: Invalid repository name format. Must be "owner/repo". Got: "${repoFullName}". Do NOT retry.`;
         }
+        if (repoFullName.includes('..')) {
+          return `ERROR: Repository name cannot contain directory traversal sequences. Got: "${repoFullName}". Do NOT retry.`;
+        }
+
+        const parts = repoFullName.split('/');
         const [owner, repo] = parts;
         const folderName = `${owner}-${repo}`;
         const cloneDir = path.join(TICLAW_HOME, 'factory', folderName);
@@ -54,7 +60,7 @@ export const buildWorkspaceTool = (
 
         if (operation === 'update') {
           if (fs.existsSync(cloneDir)) {
-            execSync('git pull', { cwd: cloneDir, timeout: 60000 });
+            execFileSync('git', ['pull'], { cwd: cloneDir, timeout: 60000 });
             return `Successfully updated workspace for ${repoFullName} (git pull complete).`;
           } else {
             return `ERROR: Workspace for ${repoFullName} does not exist. Set it up first.`;
@@ -64,8 +70,16 @@ export const buildWorkspaceTool = (
         if (operation === 'setup') {
           if (!fs.existsSync(cloneDir)) {
             fs.mkdirSync(path.dirname(cloneDir), { recursive: true });
-            execSync(
-              `git clone --branch main --single-branch https://github.com/${repoFullName}.git ${cloneDir}`,
+            execFileSync(
+              'git',
+              [
+                'clone',
+                '--branch',
+                'main',
+                '--single-branch',
+                `https://github.com/${repoFullName}.git`,
+                cloneDir,
+              ],
               { timeout: 60000 },
             );
           }


### PR DESCRIPTION
This patch addresses several issues discovered during code review. Specifically, it hardens `src/tools/workspace.ts` against command injection by switching to `execFileSync` and validating the requested repository name via regex and traversal checks. It also updates the unit tests to pass by correcting module import paths and properly mocking out the AI generated step counts. Lastly, `package.json` specifies allowed native build scripts for pnpm.

---
*PR created automatically by Jules for task [4279774969756238989](https://jules.google.com/task/4279774969756238989) started by @hughlv*