### PR TITLE
Fix tests and pnpm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,4 +45,8 @@
   "engines": {
     "node": ">=20"
   }
+,
+  "pnpm": {
+    "onlyBuiltDependencies": ["better-sqlite3", "esbuild"]
+  }
 }

--- a/src/__tests__/agent.test.ts
+++ b/src/__tests__/agent.test.ts
@@ -3,20 +3,24 @@ import { runAgentOrchestrator } from '../agent.js';
 import * as ai from 'ai';
 
 // Mock the AI SDK and dependencies
-vi.mock('ai', () => ({
-  generateText: vi.fn(),
-  tool: vi.fn((x) => x),
-}));
+vi.mock('ai', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('ai')>();
+  return {
+    ...actual,
+    generateText: vi.fn(),
+    tool: vi.fn((x) => x),
+  };
+});
 
 vi.mock('@openrouter/ai-sdk-provider', () => ({
   createOpenRouter: vi.fn().mockReturnValue(() => 'mock-model'),
 }));
 
-vi.mock('../env.js', () => ({
+vi.mock('../core/env.js', () => ({
   readEnvFile: vi.fn().mockReturnValue({ OPENROUTER_API_KEY: 'test-key' }),
 }));
 
-vi.mock('../logger.js', () => ({
+vi.mock('../core/logger.js', () => ({
   logger: {
     info: vi.fn(),
     error: vi.fn(),
@@ -27,15 +31,14 @@ vi.mock('../logger.js', () => ({
 
 // Mock the tools
 vi.mock('../tools/executor.js', () => ({
-  buildExecutorTool: vi.fn().mockReturnValue({
-    execute: vi.fn().mockResolvedValue('Executor called'),
+  buildSessionTools: vi.fn().mockReturnValue({
+    captureSessionTool: vi.fn((x) => x),
+    sendToSessionTool: vi.fn((x) => x),
   }),
 }));
 
-vi.mock('../tools/setup-workspace.js', () => ({
-  buildSetupWorkspaceTool: vi.fn().mockReturnValue({
-    execute: vi.fn().mockResolvedValue('Setup called'),
-  }),
+vi.mock('../tools/workspace.js', () => ({
+  buildWorkspaceTool: vi.fn().mockReturnValue(vi.fn((x) => x)),
 }));
 
 describe('Agent Orchestrator', () => {
@@ -47,6 +50,7 @@ describe('Agent Orchestrator', () => {
       trigger: '@TC',
       added_at: new Date().toISOString(),
       isMain: false,
+      requiresTrigger: false,
     },
     workspacePath: '/tmp/workspace',
     isMain: false,
@@ -62,12 +66,17 @@ describe('Agent Orchestrator', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    process.env.OPENROUTER_API_KEY = 'test-key';
   });
 
   it('should call generateText with correct model and tools', async () => {
-    vi.mocked(ai.generateText).mockResolvedValueOnce({
+    vi.mocked(ai.generateText).mockResolvedValue({
       text: 'I have scheduled the requested work via tools.',
-      toolCalls: [],
+      steps: [{ toolCalls: [] }],
+      finishReason: 'stop',
+      usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+      warnings: [],
+      rawResponse: { headers: {} }
     } as any);
 
     const result = await runAgentOrchestrator(dummyOpts);
@@ -76,7 +85,8 @@ describe('Agent Orchestrator', () => {
     const callArgs = vi.mocked(ai.generateText).mock.calls[0][0];
 
     expect((callArgs as any).system).toContain('You are TiClaw');
-    expect((callArgs as any).tools).toHaveProperty('executorTool');
+    expect((callArgs as any).tools).toHaveProperty('captureSessionTool');
+    expect((callArgs as any).tools).toHaveProperty('sendToSessionTool');
     expect((callArgs as any).tools).toHaveProperty('workspaceTool');
 
     expect(result).toBe('I have scheduled the requested work via tools.');


### PR DESCRIPTION
Fix tests and pnpm dependencies

- Update `pnpm` to only build `better-sqlite3` and `esbuild` dependencies
- Fix `src/__tests__/agent.test.ts` to use correct tool names (`captureSessionTool`, `sendToSessionTool`, `workspaceTool`)
- Fix `src/__tests__/agent.test.ts` to properly mock the `ai` module by preserving original exports using `importOriginal`
- Set `OPENROUTER_API_KEY` in `beforeEach` to fix env key missing errors

---
*PR created automatically by Jules for task [5461141531586432255](https://jules.google.com/task/5461141531586432255) started by @hughlv*