### PR TITLE
fix: test failures and dependency build issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,11 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild"
+    ]
   }
 }

--- a/src/__tests__/agent.test.ts
+++ b/src/__tests__/agent.test.ts
@@ -6,6 +6,7 @@ import * as ai from 'ai';
 vi.mock('ai', () => ({
   generateText: vi.fn(),
   tool: vi.fn((x) => x),
+  stepCountIs: vi.fn(),
 }));
 
 vi.mock('@openrouter/ai-sdk-provider', () => ({
@@ -27,13 +28,14 @@ vi.mock('../logger.js', () => ({
 
 // Mock the tools
 vi.mock('../tools/executor.js', () => ({
-  buildExecutorTool: vi.fn().mockReturnValue({
-    execute: vi.fn().mockResolvedValue('Executor called'),
+  buildSessionTools: vi.fn().mockReturnValue({
+    captureSessionTool: vi.fn().mockReturnValue({ execute: vi.fn() }),
+    sendToSessionTool: vi.fn().mockReturnValue({ execute: vi.fn() }),
   }),
 }));
 
-vi.mock('../tools/setup-workspace.js', () => ({
-  buildSetupWorkspaceTool: vi.fn().mockReturnValue({
+vi.mock('../tools/workspace.js', () => ({
+  buildWorkspaceTool: vi.fn().mockReturnValue({
     execute: vi.fn().mockResolvedValue('Setup called'),
   }),
 }));
@@ -68,6 +70,7 @@ describe('Agent Orchestrator', () => {
     vi.mocked(ai.generateText).mockResolvedValueOnce({
       text: 'I have scheduled the requested work via tools.',
       toolCalls: [],
+      steps: [],
     } as any);
 
     const result = await runAgentOrchestrator(dummyOpts);
@@ -76,7 +79,8 @@ describe('Agent Orchestrator', () => {
     const callArgs = vi.mocked(ai.generateText).mock.calls[0][0];
 
     expect((callArgs as any).system).toContain('You are TiClaw');
-    expect((callArgs as any).tools).toHaveProperty('executorTool');
+    expect((callArgs as any).tools).toHaveProperty('captureSessionTool');
+    expect((callArgs as any).tools).toHaveProperty('sendToSessionTool');
     expect((callArgs as any).tools).toHaveProperty('workspaceTool');
 
     expect(result).toBe('I have scheduled the requested work via tools.');

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -37,8 +37,8 @@ describe('router', () => {
     });
 
     it('should not remove unfinished internal tags', () => {
-        const input = 'Hello <internal>unclosed';
-        expect(stripInternalTags(input)).toBe('Hello <internal>unclosed');
+      const input = 'Hello <internal>unclosed';
+      expect(stripInternalTags(input)).toBe('Hello <internal>unclosed');
     });
   });
 


### PR DESCRIPTION
fix: test failures and dependency build issues

- Resolved `better-sqlite3` and `esbuild` native module build issues by listing them in `pnpm.onlyBuiltDependencies` within `package.json`.
- Updated `src/__tests__/agent.test.ts` to reflect correct mock methods for `buildSessionTools` and `buildWorkspaceTool` rather than outdated `buildExecutorTool` and `buildSetupWorkspaceTool`.
- Adjusted expectations for updated `ai.generateText` tool response structure which expects a `steps` field.

---
*PR created automatically by Jules for task [8468672794213769654](https://jules.google.com/task/8468672794213769654) started by @hughlv*